### PR TITLE
Fixes #20564: node_settings module should not throw an exception when no token is passed and the playbook is not run on the rudder server

### DIFF
--- a/plugins/modules/node_settings.py
+++ b/plugins/modules/node_settings.py
@@ -207,8 +207,14 @@ class RudderNodeSettingsInterface(object):
             self.rudder_url = 'https://localhost/rudder'
             self.validate_certs = False
         if module.params.get('rudder_token', None) is None:
-            with open('/var/rudder/run/api-token') as system_token:
-                token = system_token.read()
+            try:
+                with open('/var/rudder/run/api-token') as system_token:
+                    token = system_token.read()
+            except FileNotFoundError:
+                self._module.fail_json(
+                    failed=True,
+                    msg="No token found in parameters, could not find the default system token under '/var/rudder/run/api-token'.",
+                )
         else:
             token = module.params['rudder_token']
         self.headers = {

--- a/plugins/modules/server_settings.py
+++ b/plugins/modules/server_settings.py
@@ -84,8 +84,14 @@ class RudderSettingsInterface(object):
             self.rudder_url = 'https://localhost/rudder'
             self.validate_certs = False
         if module.params.get('rudder_token', None) is None:
-            with open('/var/rudder/run/api-token') as system_token:
-                token = system_token.read()
+            try:
+                with open('/var/rudder/run/api-token') as system_token:
+                    token = system_token.read()
+            except FileNotFoundError:
+                self._module.fail_json(
+                    failed=True,
+                    msg="No token found in parameters, could not find the default system token under '/var/rudder/run/api-token'.",
+                )
         else:
             token = module.params['rudder_token']
         self.headers = {


### PR DESCRIPTION
https://issues.rudder.io/issues/20564