### PR TITLE
Adding a working example for Ansible 2.12. Server and agents to that srv

### DIFF
--- a/roles/rudder_server/README.md
+++ b/roles/rudder_server/README.md
@@ -24,3 +24,33 @@
           vars:
             server_version: 7.0
 ```
+
+#### Example playbook: server and agents connect to that server
+
+From: https://github.com/safespring-community/terraform-modules/tree/main/examples/v2-rudder-minimal-poc
+```yaml
+
+- name: Install Rudder Server
+  hosts: server
+  become: yes
+  collections:
+    - rudder.rudder
+  tasks:
+    - import_role:
+        name: rudder.rudder.rudder_server
+      vars:
+        server_version: 7.0
+
+- name: Install Rudder agents
+  hosts: agents_host_group
+  become: yes
+  collections:
+    - rudder.rudder
+  tasks:
+    - import_role:
+        name: rudder.rudder.rudder_agent
+      vars:
+        agent_version: 7.0
+        policy_server: "{{hostvars['hostname_of_server']['ansible_default_ipv4']['address']}}"
+
+```


### PR DESCRIPTION
I could not get the existing example playbook code to work with Ansible 2.12. This example shows a successful install of server, agents and bootstrap of those agents to the server, and a reference to our Terraform/Ansible/Openstack example. 

Test was done with Ubuntu 20.04